### PR TITLE
fix: make netbox data load idempotent

### DIFF
--- a/etc/netbox/entrypoint.sh
+++ b/etc/netbox/entrypoint.sh
@@ -1,10 +1,19 @@
 #!/bin/bash
 
-if [ -f "/etc/netbox/data.json" ]; then
-    echo "Loading data from  /etc/netbox/data.json"
-    /opt/netbox/netbox/manage.py loaddata -v 3 /etc/netbox/data.json
+data_file="/etc/netbox/data.json"
+populated_file="/tmp/data_populated"
+
+if [ -f "$populated_file" ]; then
+    echo "⏭️ Data has already been loaded. Skipping data population step..."
 else
-    echo "no data to load"
+    if [ -f "$data_file" ]; then
+        echo "⏳ Loading data from $data_file"
+        /opt/netbox/netbox/manage.py loaddata -v 3 "$data_file"
+        echo "✅ Finished loading data from $data_file"
+        touch "$populated_file"
+    else
+        echo "⚠️ No data file found to load into netbox!"
+    fi
 fi
 
 /opt/netbox/launch-netbox.sh


### PR DESCRIPTION
Previously netbox data loading wasn't idempotent, and would result in you paving over the netbox data created by the orch if you restart the container. This PR makes this action idempotent by adding a file to `/tmp` that exists after data has been populated. We then skip data population if that file exists. 

To re-force data population, you can simply do a `docker compose down -v` to remove the volume (and all the data and the file in `/tmp`